### PR TITLE
Fix race condition causing incorrect mods being shown for mac users

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,10 +77,13 @@ function compareVersion(one, two) {
 }
 
 $(document).ready(() => {
-    let promise = fetch("https://raw.githubusercontent.com/tildejustin/mcsr-meta/schema-6/important_versions.json").then(response => response.json()).then(it => minecraft_versions.push(...it)).then(_ => initVersions())
-    fetch("https://raw.githubusercontent.com/tildejustin/mcsr-meta/schema-6/mods.json").then(response => response.json()).then(async json => {
-        // wait for initVersions to have gone through, so correct OS is detected
-        await promise;
+  Promise.all([
+    fetch("https://raw.githubusercontent.com/tildejustin/mcsr-meta/schema-6/important_versions.json"),
+    fetch("https://raw.githubusercontent.com/tildejustin/mcsr-meta/schema-6/mods.json"),
+  ].map(p => p.then(r => r.json()))
+  ).then(([iv, json]) => {
+        minecraft_versions.push(...iv);
+        initVersions();
         for (const mod of json.mods) {
             mods.push(mod)
         }

--- a/index.js
+++ b/index.js
@@ -77,8 +77,10 @@ function compareVersion(one, two) {
 }
 
 $(document).ready(() => {
-    fetch("https://raw.githubusercontent.com/tildejustin/mcsr-meta/schema-6/important_versions.json").then(response => response.json()).then(it => minecraft_versions.push(...it)).then(_ => initVersions())
-    fetch("https://raw.githubusercontent.com/tildejustin/mcsr-meta/schema-6/mods.json").then(response => response.json()).then(json => {
+    let promise = fetch("https://raw.githubusercontent.com/tildejustin/mcsr-meta/schema-6/important_versions.json").then(response => response.json()).then(it => minecraft_versions.push(...it)).then(_ => initVersions())
+    fetch("https://raw.githubusercontent.com/tildejustin/mcsr-meta/schema-6/mods.json").then(response => response.json()).then(async json => {
+        // wait for initVersions to have gone through, so correct OS is detected
+        await promise;
         for (const mod of json.mods) {
             mods.push(mod)
         }


### PR DESCRIPTION
The order in which these two web requests return currently impacts if the mod list shows the windows version or respects the detected OS version, I added an await statement to fix this. Without this about 1/4 page loads would result in the windows mod list being displayed

if async/await syntax is being purposefully avoided, (though it should be supported in practically every major browser)
Then I believe the same could be accomplished using the Promise.all function
https://caniuse.com/mdn-javascript_operators_await
let me know if you want me to rewrite it that way

Also this should not affect the speed of page load, as the await happens after both web requests are sent.